### PR TITLE
Updates API user documentation with phone and address details

### DIFF
--- a/chapters/04-users.md
+++ b/chapters/04-users.md
@@ -67,13 +67,13 @@ Content-Type: application/json
   "familyName": "Washburn",
   "phone": "6038929300",
     "location": {
-                "addr1": "15 New Sudbury St",
-                "city": "Boston",
-                "state": "MA",
-                "zip": "02203",              
-                "country": "United States",
-                "formatted": "15 New Sudbury St, Boston, MA, 02203, United States"
-                }
+        "addr1": "15 New Sudbury St",
+        "city": "Boston",
+        "state": "MA",
+        "zip": "02203",              
+        "country": "United States",
+        "formatted": "15 New Sudbury St, Boston, MA, 02203, United States"
+        }
 }
 ```
 


### PR DESCRIPTION
We frequently hear "where do we add a user phone number" or "where does a user address go" I decided to just update the docs. @ConnorStec check out the minor edit and approve if it looks good, please. 