### PR TITLE
ch. 3: groups: what's returned by /groups, and updated example data for /groups/:groupID

### DIFF
--- a/chapters/03-groups.md
+++ b/chapters/03-groups.md
@@ -41,7 +41,7 @@ GET     /api/organizations/{orgID}/groups
 GET     /api/organizations/{orgID}/groups/{groupID}
 ```
 ## Retrieve all groups in an organization
-Groups returned by this route have a truncated set of properties. The properties that will be included are `id`, `name`, `parentID`, `parentss`, and `groupIdentifier`. For the full set of a group's properties, use the [retrieve group](#retrieve_group) route.
+Groups returned by this route have a truncated set of properties. The properties that will be included are `id`, `name`, `parentID`, `parents`, and `groupIdentifier`. For the full set of a group's properties, use the [retrieve group](#retrieve_group) route.
 
 Request:
 


### PR DESCRIPTION
Explicitly saying what's returned by the `/groups` route, and updating the example data for `/groups/:groupID`.