### PR TITLE
tags: fixing indentation

### DIFF
--- a/chapters/06-tags.md
+++ b/chapters/06-tags.md
@@ -116,7 +116,7 @@ There are several considerations needed when creating group or profile tags. The
   - There can only be one level of children for each group tag. Cannot assign a child tag's `ID` as another tag's `parentID`.
   - Cannot create tags with duplicate `value`s and `parentID`s (e.g. If there's a top-level tag with `value` 'Favorite Color', you cannot create another top-level tag with that `value`. You could create a tag with that `value` but a different `parentID`)
   - `parentID` cannot be updated
-- rofile Tags
+- Profile Tags
   - Must have a `tagID` and either an `optionID` or a `value`. Cannot have both.
   - `tagID` must point to a top-level group tag.
   - A profile can only have one profile tag for each group tag.


### PR DESCRIPTION
The indentation in our `tags` chapter is wonky. This sets it right, making the content easier to read.